### PR TITLE
integrate with backend fitness profile features

### DIFF
--- a/src/components/Dashboard.js
+++ b/src/components/Dashboard.js
@@ -31,12 +31,12 @@ const Charts = ({ data, loading }) => {
             valueMin={0}
             valueMax={
               data.daily_macros.calorie_limit
-                ? Math.round(data.daily_macros.calorie_limit)
+                ? Math.round(data.daily_macros.daily_calorie_limit)
                 : 2000
             }
           />
           <Typography variant="caption">
-            {`You have ${Math.round((data.daily_macros.calorie_limit ? data.daily_macros.calorie_limit : 2000) - data.daily_macros.total_calories)} calories remaining for the day.`}
+            {`You have ${Math.round((data.daily_macros.daily_calorie_limit ? data.daily_macros.daily_calorie_limit : 2000) - data.daily_macros.total_calories)} calories remaining for the day.`}
           </Typography>
         </Box>
         <MacroChart

--- a/src/components/MacroChart.js
+++ b/src/components/MacroChart.js
@@ -3,7 +3,7 @@ import { PieChart } from "@mui/x-charts";
 
 const MacroChart = ({ data, hidden }) => {
   const chartData = Object.entries(data).map(([k, v], i) => {
-    if (k === "total_calories") {
+    if (k === "total_calories" || k === "daily_calorie_limit") {
       return null;
     }
     return { id: i, value: v, label: k.split("_")[1] };

--- a/src/components/Profile.js
+++ b/src/components/Profile.js
@@ -8,8 +8,11 @@ import {
   MenuItem,
   FormControl,
   Typography,
+  CircularProgress,
 } from "@mui/material";
-import { useState } from "react";
+import { useEffect, useState } from "react";
+import { toast } from "react-toastify";
+import { getUserProfile, updateUserProfile } from "../services/userService";
 
 const tmpProfile = {
   height: 177.8,
@@ -22,7 +25,7 @@ const tmpProfile = {
 
 const Profile = () => {
   const [isEditing, setIsEditing] = useState(false);
-  const [profile, setProfile] = useState(tmpProfile);
+  const [profile, setProfile] = useState(null);
 
   const handleProfileChange = (e) =>
     setProfile((prev) => ({
@@ -31,8 +34,26 @@ const Profile = () => {
     }));
 
   const handleEditClicked = () => {
+    if (isEditing) {
+      toast.promise(
+        updateUserProfile(profile).then((res) => setProfile(res.data)),
+        {
+          pending: "Updating profile information...",
+          success: "Successfully updated profile information!",
+          error: "Failed to update profile information",
+        },
+      );
+    }
     setIsEditing(!isEditing);
   };
+
+  useEffect(() => {
+    getUserProfile().then((res) => setProfile(res.data.fitness_profile));
+  }, []);
+
+  if (!profile) {
+    return <CircularProgress />;
+  }
 
   return (
     <Paper

--- a/src/services/userService.js
+++ b/src/services/userService.js
@@ -67,3 +67,13 @@ export const searchFoods = (query) =>
   axios.get(`${API_URL}/foods/search/${query}`, {
     headers: { Authorization: `Token ${localStorage.getItem("quatro-token")}` },
   });
+
+export const getUserProfile = () =>
+  axios.get(`${API_URL}/users/account/`, {
+    headers: { Authorization: `Token ${localStorage.getItem("quatro-token")}` },
+  });
+
+export const updateUserProfile = (profile) =>
+  axios.put(`${API_URL}/users/fitness-profile/`, profile, {
+    headers: { Authorization: `Token ${localStorage.getItem("quatro-token")}` },
+  });


### PR DESCRIPTION
**Summary:**
Add support for fitness profile features

**Examples:**
Edit fitness profile settings
![settings-new](https://github.com/user-attachments/assets/24427790-5700-4552-baa4-2e47a308e435)

Dashboard now uses the results of calculating BMR with settings to display daily caloric goals (no longer using default of 2000)
![dashboard-with-profile-support](https://github.com/user-attachments/assets/e2f81eca-7e95-4b89-ac2c-7f50e1e5e9ab)
